### PR TITLE
Update .lintstagedrc.json

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{ts,tsx}": ["eslint 'src/**' --fix", "yarn test:staged"]
+  "*.{ts,tsx}": ["eslint 'src/**' --fix", "yarn test:staged", "git add"]
 }


### PR DESCRIPTION
Colocando o `git add` após o processo de linting do eslint fará com que o lint-staged readicione ao status de staged os arquivos que sofreram modificações por esse processo, assim não será necessário adiciona-los novamente